### PR TITLE
Packyears fix

### DIFF
--- a/R/smoking.R
+++ b/R/smoking.R
@@ -283,7 +283,7 @@ pack_years_fun <-
         if_else2(
           SMKDSTY_A == 2, pmax(((DHHGAGE_cont - SMKG207_cont -
                                  time_quit_smoking) * (SMK_208 / 20)), 0.0137) +
-            (pmax((SMK_05B * SMK_05C / 30), 1) *time_quit_smoking),
+            ((pmax((SMK_05B * SMK_05C / 30), 1) / 20) * time_quit_smoking),
           # PackYears for Occasional Smoker (never daily)
           if_else2(
             SMKDSTY_A == 3, (pmax((SMK_05B * SMK_05C / 30), 1) / 20) *

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,15 @@
+# Testing a derived function
+
+The `test_derived_function` should be used when testing a derived function. This
+helper function is stored within the `tests/testthat/helper-utils.R` file. The
+recommended workflow with this function is to:
+
+1. Create a CSV file that has all your test cases for the derived function
+   within the `tests/testdata` folder
+2. Create a testthat test case that reads in that CSV file using the `read.csv`
+   function
+3. Call the `test_derived_function` function within the test case with the 
+   read in CSV file and the function to test
+
+Take a look at the `pack_years_fun` test within the
+`tests/testthat/test-smoking.R` file for an example.

--- a/tests/testdata/pack_years.csv
+++ b/tests/testdata/pack_years.csv
@@ -1,0 +1,2 @@
+SMKDSTY_A,DHHGAGE_cont,time_quit_smoking,SMKG203_cont,SMKG207_cont,SMK_204,SMK_05B,SMK_208,SMK_05C,SMKG01C_cont,SMK_01A,expected,notes
+2,45,10,NA,21,NA,5,20,15,NA,NA,15.25,Current occasional smoker but former daily smoker

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -1,0 +1,40 @@
+#' Test a derived function created to run within recodeflow
+#'
+#' @param test_data A data.frame containing the data to test the function
+#' against. The columns of the data.frame should contain all the arguments to 
+#' the derived function. It should also contain a column called `expected`
+#' which contains the expected value and a column called `notes` which is diplayed
+#' when the test fails. The notes columns should describe briefly what the 
+#' row is testing.
+#' @param derived_function the derived function to test
+#' @examples
+#' BMI <- function(height, weight) {
+#'   return(height/(weight*weight))
+#' }
+#' 
+#' test_data <- data.frame(
+#'    height = c(185, 160),
+#'    weight = c(85, 70),
+#'    expected = c(24.8, 27.3),
+#'    notes = c("Normal weight", "Overweight")
+#' )
+#'
+#' test_derived_function(test_data, BMI)
+test_derived_function <- function(test_data, derived_function) {
+  for(i in seq_len(nrow(test_data))) {
+    test_datum <- test_data[i, ]
+    arguments <- list()
+    for(column in colnames(test_datum)) {
+      if(column != "expected" & column != "notes") {
+        arguments[[column]] <- test_datum[[column]]
+      }
+    }
+    actual <- do.call(derived_function, arguments)
+
+    expect_equal(
+      actual,
+      test_datum$expected,
+      info = paste("Error in row", i, "when testing", test_datum$notes)
+    )
+  }
+}

--- a/tests/testthat/test-smoking.R
+++ b/tests/testthat/test-smoking.R
@@ -42,6 +42,14 @@ test_that("pack_years_fun() has expected outputs when
                          12)
           })
 
+test_that("pack_years_fun", {
+  test_derived_function(
+    test_data <- read.csv("../testdata/pack_years.csv"),
+    pack_years_fun
+  )
+})
+
+
 test_that("pack_years_fun_cat() has expected outputs when
           pack_years_der is out of range", {
             expect_equal(pack_years_fun_cat(-1),


### PR DESCRIPTION
Number of cigs per month wasn't being converted to packyears per month for current occasional, former daily smokers, which is done by dividing by 20. Thanks to @reikookamoto for finding this bug!